### PR TITLE
Thêm chức năng lấy thông tin sản phẩm cho quản trị viên và cải thiện cấu trúc mã nguồn

### DIFF
--- a/apple-shop/src/main/java/com/web/appleshop/controller/AdminProductController.java
+++ b/apple-shop/src/main/java/com/web/appleshop/controller/AdminProductController.java
@@ -1,15 +1,11 @@
 package com.web.appleshop.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.web.appleshop.dto.request.CreateProductRequest;
-import com.web.appleshop.dto.request.UpdateProductRequest;
 import com.web.appleshop.dto.response.ApiResponse;
 import com.web.appleshop.dto.response.PageableResponse;
 import com.web.appleshop.dto.response.ProductAdminResponse;
 import com.web.appleshop.entity.User;
-import com.web.appleshop.security.JwtAuthenticationFilter;
 import com.web.appleshop.service.ProductService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -22,15 +18,10 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("admin/products")
+@RequiredArgsConstructor
 public class AdminProductController {
 
     private final ProductService productService;
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
-
-    public AdminProductController(ProductService productService, JwtAuthenticationFilter jwtAuthenticationFilter) {
-        this.productService = productService;
-        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
-    }
 
     @PostMapping(consumes = {"multipart/form-data"})
     public ResponseEntity<ApiResponse<String>> createProduct(
@@ -65,5 +56,11 @@ public class AdminProductController {
                 productAdminResponsePage.getTotalElements()
         );
         return ResponseEntity.ok(ApiResponse.success(productAdminResponsePage.getContent(), "Get all products successfully", pageableResponse));
+    }
+
+    @GetMapping("{categoryId}/{productId}")
+    public ResponseEntity<ApiResponse<ProductAdminResponse>> getProduct(@PathVariable Integer categoryId, @PathVariable Integer productId) {
+        ProductAdminResponse productAdminResponse = productService.getProductByProductIdForAdmin(categoryId, productId);
+        return ResponseEntity.ok(ApiResponse.success(productAdminResponse, "Get product successfully"));
     }
 }

--- a/apple-shop/src/main/java/com/web/appleshop/dto/response/ProductAdminResponse.java
+++ b/apple-shop/src/main/java/com/web/appleshop/dto/response/ProductAdminResponse.java
@@ -34,7 +34,6 @@ public class ProductAdminResponse implements Serializable {
         String firstName;
         String lastName;
         String image;
-        String username;
     }
 
     /**
@@ -47,7 +46,6 @@ public class ProductAdminResponse implements Serializable {
         String firstName;
         String lastName;
         String image;
-        String username;
     }
 
     /**

--- a/apple-shop/src/main/java/com/web/appleshop/service/ProductService.java
+++ b/apple-shop/src/main/java/com/web/appleshop/service/ProductService.java
@@ -15,4 +15,5 @@ public interface ProductService {
     Page<ProductAdminResponse> getAllProductsForAdmin(Pageable pageable);
     Page<ProductUserResponse> getProductsByCategoryIdForUser(Integer categoryId, Pageable pageable);
     ProductUserResponse getProductByProductIdForUser(Integer categoryId, Integer productId);
+    ProductAdminResponse getProductByProductIdForAdmin(Integer categoryId, Integer productId);
 }

--- a/apple-shop/src/main/java/com/web/appleshop/service/impl/ProductServiceImpl.java
+++ b/apple-shop/src/main/java/com/web/appleshop/service/impl/ProductServiceImpl.java
@@ -329,6 +329,15 @@ public class ProductServiceImpl implements ProductService {
         return convertProductToProductUserResponse(product);
     }
 
+    @Override
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN', 'ROLE_STAFF')")
+    public ProductAdminResponse getProductByProductIdForAdmin(Integer categoryId, Integer productId) {
+        Product product = productRepository.findProductByIdAndCategory_Id(productId, categoryId).orElseThrow(
+                () -> new NotFoundException("Product not found with id: " + productId + " and category id: " + categoryId)
+        );
+        return convertProductToProductAdminResponse(product);
+    }
+
     public ProductUserResponse convertProductToProductUserResponse(Product product) {
         Set<ProductUserResponse.ProductStockResponse> stockDtos = new LinkedHashSet<>();
         for (Stock stock : product.getStocks()) {
@@ -344,10 +353,10 @@ public class ProductServiceImpl implements ProductService {
     @PreAuthorize("hasAnyAuthority('ROLE_ADMIN', 'ROLE_STAFF')")
     public ProductAdminResponse convertProductToProductAdminResponse(Product product) {
         User createdByEntity = product.getCreatedBy();
-        ProductAdminResponse.ProductOwnerAdminResponse createdByDto = new ProductAdminResponse.ProductOwnerAdminResponse(createdByEntity.getId(), createdByEntity.getEmail(), createdByEntity.getFirstName(), createdByEntity.getLastName(), createdByEntity.getImage(), createdByEntity.getUsername());
+        ProductAdminResponse.ProductOwnerAdminResponse createdByDto = new ProductAdminResponse.ProductOwnerAdminResponse(createdByEntity.getId(), createdByEntity.getEmail(), createdByEntity.getFirstName(), createdByEntity.getLastName(), createdByEntity.getImage());
 
         User updatedByEntity = product.getUpdatedBy();
-        ProductAdminResponse.ProductUpdatedAdminResponse updatedByDto = new ProductAdminResponse.ProductUpdatedAdminResponse(updatedByEntity.getId(), updatedByEntity.getEmail(), updatedByEntity.getFirstName(), updatedByEntity.getLastName(), updatedByEntity.getImage(), updatedByEntity.getUsername());
+        ProductAdminResponse.ProductUpdatedAdminResponse updatedByDto = new ProductAdminResponse.ProductUpdatedAdminResponse(updatedByEntity.getId(), updatedByEntity.getEmail(), updatedByEntity.getFirstName(), updatedByEntity.getLastName(), updatedByEntity.getImage());
 
         Category categoryEntity = product.getCategory();
         ProductAdminResponse.ProductCategoryAdminResponse categoryDto = new ProductAdminResponse.ProductCategoryAdminResponse(categoryEntity.getId(), categoryEntity.getName(), categoryEntity.getImage());

--- a/apple-shop/src/test/java/com/web/appleshop/controller/AdminProductControllerTest.java
+++ b/apple-shop/src/test/java/com/web/appleshop/controller/AdminProductControllerTest.java
@@ -43,12 +43,12 @@ class AdminProductControllerTest {
         // Create sample data for testing
         ProductAdminResponse.ProductOwnerAdminResponse createdBy = 
             new ProductAdminResponse.ProductOwnerAdminResponse(
-                1, "admin@example.com", "John", "Doe", "image.jpg", "admin"
+                1, "admin@example.com", "John", "Doe", "image.jpg"
             );
 
         ProductAdminResponse.ProductUpdatedAdminResponse updatedBy = 
             new ProductAdminResponse.ProductUpdatedAdminResponse(
-                1, "admin@example.com", "John", "Doe", "image.jpg", "admin"
+                1, "admin@example.com", "John", "Doe", "image.jpg"
             );
 
         ProductAdminResponse.ProductCategoryAdminResponse category = 

--- a/apple-shop/src/test/java/com/web/appleshop/integration/AdminProductIntegrationTest.java
+++ b/apple-shop/src/test/java/com/web/appleshop/integration/AdminProductIntegrationTest.java
@@ -46,12 +46,12 @@ class AdminProductIntegrationTest {
         // Create sample data for testing
         ProductAdminResponse.ProductOwnerAdminResponse createdBy =
             new ProductAdminResponse.ProductOwnerAdminResponse(
-                1, "admin@test.com", "Test", "Admin", "test.jpg", "testadmin"
+                1, "admin@test.com", "Test", "Admin", "test.jpg"
             );
 
         ProductAdminResponse.ProductUpdatedAdminResponse updatedBy =
             new ProductAdminResponse.ProductUpdatedAdminResponse(
-                1, "admin@test.com", "Test", "Admin", "test.jpg", "testadmin"
+                1, "admin@test.com", "Test", "Admin", "test.jpg"
             );
 
         ProductAdminResponse.ProductCategoryAdminResponse category =
@@ -100,8 +100,6 @@ class AdminProductIntegrationTest {
         assertThat(response.getBody().getData().getFirst().getId()).isEqualTo(1);
         assertThat(response.getBody().getData().getFirst().getName()).isEqualTo("Test iPhone");
         assertThat(response.getBody().getData().getFirst().getDescription()).isEqualTo("Test iPhone description");
-        assertThat(response.getBody().getData().getFirst().getCreatedBy().getUsername()).isEqualTo("testadmin");
-        assertThat(response.getBody().getData().getFirst().getUpdatedBy().getUsername()).isEqualTo("testadmin");
         assertThat(response.getBody().getData().getFirst().getCategory().getName()).isEqualTo("Test Electronics");
         assertThat(response.getBody().getData().getFirst().getStocks()).hasSize(1);
         assertThat(response.getBody().getMeta()).isNotNull();

--- a/apple-shop/src/test/java/com/web/appleshop/service/impl/ProductServiceImplTest.java
+++ b/apple-shop/src/test/java/com/web/appleshop/service/impl/ProductServiceImplTest.java
@@ -178,8 +178,7 @@ class ProductServiceImplTest {
         assertThat(result.getCreatedBy().getEmail()).isEqualTo("admin@example.com");
         assertThat(result.getCreatedBy().getFirstName()).isEqualTo("John");
         assertThat(result.getCreatedBy().getLastName()).isEqualTo("Doe");
-        assertThat(result.getCreatedBy().getUsername()).isEqualTo("admin");
-        
+
         // Verify updatedBy mapping
         assertThat(result.getUpdatedBy()).isNotNull();
         assertThat(result.getUpdatedBy().getId()).isEqualTo(1);


### PR DESCRIPTION
Pull request này giới thiệu một số cập nhật cho AdminProductController, ProductAdminResponse và các tệp service, test liên quan trong dự án apple-shop. Các thay đổi bao gồm việc đơn giản hóa mã nguồn bằng cách loại bỏ các trường không cần thiết, thêm một endpoint mới để lấy chi tiết sản phẩm riêng lẻ, và đảm bảo tính nhất quán giữa các implement service và các bài test.

### Cập nhật Controller:
Loại bỏ JwtAuthenticationFilter khỏi AdminProductController và tái cấu trúc constructor để sử dụng @RequiredArgsConstructor.
### Thêm một endpoint mới: 
GET /admin/products/{categoryId}/{productId} để lấy chi tiết sản phẩm theo danh mục và ID sản phẩm cho người dùng quản trị.
### Cập nhật DTO:
Loại bỏ trường username khỏi các lớp ProductOwnerAdminResponse và ProductUpdatedAdminResponse để đơn giản hóa cấu trúc của response.
### Cập nhật Service:
Thêm phương thức mới getProductByProductIdForAdmin trong ProductService và implement nó trong ProductServiceImpl với các kiểm tra phân quyền phù hợp.
Cập nhật phương thức convertProductToProductAdminResponse để loại bỏ trường username khỏi việc ánh xạ response cho admin.